### PR TITLE
Implement some DiskImage traits for STX

### DIFF
--- a/src/disk_format/apple/catalog.rs
+++ b/src/disk_format/apple/catalog.rs
@@ -127,7 +127,7 @@ pub struct TrackSectorList<'a> {
 }
 
 /// Display a FileType as a single character
-impl<'a> Display for TrackSectorList<'a> {
+impl Display for TrackSectorList<'_> {
     fn fmt(&self, f: &mut Formatter) -> Result {
         write!(f, "reserved: {}", self.reserved)?;
         match self.track_number_of_next_sector {
@@ -766,7 +766,7 @@ pub fn parse_catalogs<'a>(
     })
 }
 
-impl<'a> Catalog<'a> {
+impl Catalog<'_> {
     /// Get the file data for a file in the catalog
     pub fn get_file(&self, filename: &str) -> Vec<u8> {
         let _file_entry = self.catalog_by_filename.get(filename).unwrap();

--- a/src/disk_format/apple/disk.rs
+++ b/src/disk_format/apple/disk.rs
@@ -260,7 +260,7 @@ pub enum AppleDiskData<'a> {
     Nibble(NibbleDisk),
 }
 
-impl<'a> DiskImageSaver for AppleDOSDisk<'a> {
+impl DiskImageSaver for AppleDOSDisk<'_> {
     fn save_disk_image(
         &self,
         _config: &Config,
@@ -629,7 +629,7 @@ pub fn apple_disk_parser<'a>(
 }
 
 /// DiskImageParser implementation for AppleDiskGuess
-impl<'a, 'b> DiskImageParser<'a, 'b> for AppleDiskGuess<'a> {
+impl<'a> DiskImageParser<'a, '_> for AppleDiskGuess<'a> {
     fn parse_disk_image(
         &'a self,
         config: &'a crate::config::Config,

--- a/src/disk_format/stx/track.rs
+++ b/src/disk_format/stx/track.rs
@@ -1,4 +1,4 @@
-use log::{debug, error, info};
+use log::{debug, error};
 use nom::bytes::complete::take;
 use nom::combinator::cond;
 use nom::multi::count;
@@ -215,7 +215,7 @@ pub fn stx_track_parser(i: &[u8]) -> IResult<&[u8], STXTrack> {
         }
         // Find out how many sector headers to parse
 
-        info!("Track header: {}", stx_track_header);
+        debug!("Track header: {}", stx_track_header);
         // Parse the STX sector headers
         // The last track has issues parsing in some cases, we hit EOF
         // The last tracks are sometimes flag 0x21 and not 0x61, we need to
@@ -228,7 +228,7 @@ pub fn stx_track_parser(i: &[u8]) -> IResult<&[u8], STXTrack> {
             let stx_sector_headers = stx_sector_headers_result.1;
             let sector_header_iter = stx_sector_headers.iter();
             for header in sector_header_iter {
-                info!("stx_sector_header: {}", header);
+                debug!("stx_sector_header: {}", header);
             }
 
             // Skip past the fuzzy mask record
@@ -245,7 +245,7 @@ pub fn stx_track_parser(i: &[u8]) -> IResult<&[u8], STXTrack> {
             // just read in the track image data
             let stx_track_image_header_result =
                 stx_track_image_header_parser(stx_track_header.flags)(i)?;
-            info!(
+            debug!(
                 "stx_track_image_header: {}",
                 stx_track_image_header_result.1
             );


### PR DESCRIPTION
Hi, thank you for this project!

I was looking for a way to unpack `*.stx` images without mounting them into Hatari and copying files within the emulator and with the small changes in this PR, converting the STX to a ST (which _can_ be mounted using `sudo mount -r -o loop mydisk.st /mnt/floppy/`) worked flawlessly!

I changed some `info!` to `debug!` and addressed some clippy lints to reduce the noise in my IDE and console, hope that's ok,